### PR TITLE
add support for x86_64 and libvirt using virt-install

### DIFF
--- a/slemicro/README.md
+++ b/slemicro/README.md
@@ -117,6 +117,16 @@ VM IP: 192.168.206.60
 After Rancher is installed, you can access the Web UI as https://192.168.206.60.sslip.io
 ```
 
+You could also pass as a parameter the name of the VM to be used overriding the default one.
+
+```bash
+$ ./create_vm.sh mynewvm
+VM started. You can connect to the serial terminal as: screen /dev/ttys001
+Waiting for IP: ................
+VM IP: 192.168.206.60
+After Rancher is installed, you can access the Web UI as https://192.168.206.60.sslip.io
+```
+
 ## delete_vm.sh
 
 This script is intended to easily delete the previously SLE Micro aarch64 VM on OSX using UTM.

--- a/slemicro/combustion/script
+++ b/slemicro/combustion/script
@@ -300,7 +300,7 @@ if [ "${RANCHERBOOTSTRAPSKIP}" = true ]; then
 	#!/bin/bash
 	set -euo pipefail
 	HOST="https://$(hostname -I | awk '{print $1}').sslip.io"
-
+  export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 	while ! kubectl wait --for condition=ready -n cattle-system $(kubectl get pods -n cattle-system -l app=rancher -o name) --timeout=10s; do sleep 2 ; done
 
 	# Get token

--- a/slemicro/create_vm.sh
+++ b/slemicro/create_vm.sh
@@ -10,12 +10,21 @@ die(){
 # Get the env file
 source ${BASEDIR}/.env
 
+if [ $# -eq 1 ]; then
+    VMNAME=$1
+fi
 VMFOLDER="${VMFOLDER:-~/VMs}"
 
-# Check if UTM version is 4.2.2 (required for the scripting part)
-ver(){ printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
-UTMVERSION=$(/usr/libexec/plistbuddy -c Print:CFBundleShortVersionString: /Applications/UTM.app/Contents/info.plist)
-[ $(ver ${UTMVERSION}) -lt $(ver 4.2.2) ] && die "UTM version >= 4.2.2 required" 2
+if [ $(uname -o) == "Darwin" ]; then
+  # Check if UTM version is 4.2.2 (required for the scripting part)
+  ver(){ printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
+  UTMVERSION=$(/usr/libexec/plistbuddy -c Print:CFBundleShortVersionString: /Applications/UTM.app/Contents/info.plist)
+  [ $(ver ${UTMVERSION}) -lt $(ver 4.2.2) ] && die "UTM version >= 4.2.2 required" 2
+elif [ $(uname -o) == "GNU/Linux" ]; then
+  command -v virt-install > /dev/null 2>&1 || die "virt-install command not found" 2
+else
+  die "Unsupported operating system" 2
+fi
 
 # Check if the commands required exist
 command -v butane > /dev/null 2>&1 || die "butane not found" 2
@@ -82,55 +91,73 @@ mkisofs -quiet -full-iso9660-filenames -o ${VMFOLDER}/ignition-and-combustion-${
 # Remove leftovers
 rm -Rf ${TMPDIR}
 
-# Create and launch the VM using UTM
-OUTPUT=$(
-osascript <<END
-tell application "UTM"
-	--- specify a boot ISO
-	set iso to POSIX file "${VMFOLDER}/ignition-and-combustion-${VMNAME}.iso"
-	-- specify the RAW file
-	set rawfile to POSIX file "${VMFOLDER}/${VMNAME}.raw"
-	--- create a new QEMU VM 
-	set vm to make new virtual machine with properties {backend:qemu, configuration:{cpu cores:${CPUS}, memory: ${MEMORY}, name:"${VMNAME}", architecture:"aarch64", drives:{{removable:true, source:iso}, {removable:false, source:rawfile}}}}
-	start vm
-	repeat
-		if status of vm is started then exit repeat
-	end repeat
-	get address of first serial port of vm
-end tell
-END
-)
+# if x86_64, convert the image to qcow2
+if [ $(uname -o) == "Darwin" ]; then
+  # Create and launch the VM using UTM
+  OUTPUT=$(osascript <<-END
+  tell application "UTM"
+    --- specify a boot ISO
+    set iso to POSIX file "${VMFOLDER}/ignition-and-combustion-${VMNAME}.iso"
+    -- specify the RAW file
+    set rawfile to POSIX file "${VMFOLDER}/${VMNAME}.raw"
+    --- create a new QEMU VM
+    set vm to make new virtual machine with properties {backend:qemu, configuration:{cpu cores:${CPUS}, memory: ${MEMORY}, name:"${VMNAME}", architecture:"aarch64", drives:{{removable:true, source:iso}, {removable:false, source:rawfile}}}}
+    start vm
+    repeat
+      if status of vm is started then exit repeat
+    end repeat
+    get address of first serial port of vm
+  end tell
+  END
+  )
 
-echo "VM started. You can connect to the serial terminal as: screen ${OUTPUT}"
+  echo "VM started. You can connect to the serial terminal as: screen ${OUTPUT}"
 
-OUTPUT=$(
-osascript <<END
-tell application "UTM"
-	set vm to virtual machine named "${VMNAME}"
-	set config to configuration of vm
-	get address of item 1 of network interfaces of config
-end tell
-END
-)
+  OUTPUT=$(
+  osascript <<-END
+  tell application "UTM"
+    set vm to virtual machine named "${VMNAME}"
+    set config to configuration of vm
+    get address of item 1 of network interfaces of config
+  end tell
+  END
+  )
 
-VMMAC=$(echo $OUTPUT | sed 's/0\([0-9A-Fa-f]\)/\1/g')
+  VMMAC=$(echo $OUTPUT | sed 's/0\([0-9A-Fa-f]\)/\1/g')
 
-timeout=180
-count=0
+  timeout=180
+  count=0
 
-echo -n "Waiting for IP: "
-until grep -q -i "${VMMAC}" -B1 -m1 /var/db/dhcpd_leases | head -1 | awk -F= '{ print $2 }'; do
-	count=$((count + 1))
-	if [[ ${count} -ge ${timeout} ]]; then
-		break
-	fi
-	sleep 1
-	echo -n "."
-done
-VMIP=$(grep -i "${VMMAC}" -B1 -m1 /var/db/dhcpd_leases | head -1 | awk -F= '{ print $2 }')
+  echo -n "Waiting for IP: "
+  until grep -q -i "${VMMAC}" -B1 -m1 /var/db/dhcpd_leases | head -1 | awk -F= '{ print $2 }'; do
+    count=$((count + 1))
+    if [[ ${count} -ge ${timeout} ]]; then
+      break
+    fi
+    sleep 1
+    echo -n "."
+  done
+  VMIP=$(grep -i "${VMMAC}" -B1 -m1 /var/db/dhcpd_leases | head -1 | awk -F= '{ print $2 }')
+elif [ $(uname -o) == "GNU/Linux" ]; then
+  qemu-img convert -O qcow2 ${VMFOLDER}/${VMNAME}.raw ${VMFOLDER}/${VMNAME}.qcow2
+  virt-install --name ${VMNAME} --autostart --noautoconsole --memory ${MEMORY} --vcpus ${CPUS} --disk ${VMFOLDER}/${VMNAME}.qcow2 --import --cdrom ${VMFOLDER}/ignition-and-combustion-${VMNAME}.iso --network default --osinfo detect=on,name=sle-unknown
+  echo "VM created. Waiting for IP..."
+  timeout=180
+  count=0
+  while [ $(virsh domifaddr prueba | awk -F'[ /]+' '/ipv/ {print $5}' | wc -l) -ne 1 ]; do
+      count=$((count + 1))
+      if [[ ${count} -ge ${timeout} ]]; then
+        break
+      fi
+      sleep 1
+      echo -n "."
+  done
+  VMIP=$(virsh domifaddr prueba | awk -F'[ /]+' '/ipv/ {print $5}' )
+else
+  die "VM not deployed. Unsupported operating system" 2
+fi
 
 printf "\nVM IP: ${VMIP}\n"
-
 [ ${COCKPIT} = true ] && echo "Cockpit Web UI available at https://${VMIP}.sslip.io:9090"
 [ ${RANCHER} = true ] && echo "After Rancher is installed, you can access the Web UI as https://${VMIP}.sslip.io"
 [ ${UPDATEANDREBOOT} = true ] && echo "The VM will be updated and rebooted if required, it can take a while"

--- a/slemicro/delete_vm.sh
+++ b/slemicro/delete_vm.sh
@@ -9,22 +9,32 @@ die(){
 
 # Get the env file
 source ${BASEDIR}/.env
-
+if [ $# -eq 1 ]; then
+    VMNAME=$1
+fi
 VMFOLDER="${VMFOLDER:-~/VMs}"
 
+if [ $(uname -o) == "Darwin" ]; then
 # Stop and delete the VM using UTM
-OUTPUT=$(
-osascript <<END
-tell application "UTM"
-	set vm to virtual machine named "${VMNAME}"
-	if status of vm is started then stop vm
-	repeat
-	  if status of vm is stopped then exit repeat
-  end repeat
-	delete virtual machine named "${VMNAME}"
-end tell
-END
-)
+  OUTPUT=$(
+  osascript <<-END
+  tell application "UTM"
+	  set vm to virtual machine named "${VMNAME}"
+	  if status of vm is started then stop vm
+	  repeat
+	    if status of vm is stopped then exit repeat
+    end repeat
+	  delete virtual machine named "${VMNAME}"
+  end tell
+  END
+  )
+elif [ $(uname -o) == "GNU/Linux" ]; then
+  virsh destroy ${VMNAME}
+  virsh undefine ${VMNAME}
+else
+  die "Unsupported operating system" 2
+fi
+
 
 [ -f ${VMFOLDER}/${VMNAME}.raw ] && rm -f ${VMFOLDER}/${VMNAME}.raw
 [ -f ${VMFOLDER}/ignition-and-combustion-${VMNAME}.iso ] && rm -f ${VMFOLDER}/ignition-and-combustion-${VMNAME}.iso


### PR DESCRIPTION
add support for x86_64 and libvirt using virt-install
Features:
- Autodiscovery host architecture to use virt-install or utm based on the architecture
- keep the combustion out of the switch part to re-use it for x86_64 hosts