### PR TITLE
Do not fail delete_vm.sh  when the VM no longer exists

### DIFF
--- a/slemicro/delete_vm.sh
+++ b/slemicro/delete_vm.sh
@@ -19,12 +19,14 @@ if [ $(uname -o) == "Darwin" ]; then
 	OUTPUT=$(
 	osascript <<-END
 	tell application "UTM"
-		set vm to virtual machine named "${VMNAME}"
-		if status of vm is started then stop vm
-		repeat
-			if status of vm is stopped then exit repeat
-		end repeat
-		delete virtual machine named "${VMNAME}"
+		if exists virtual machine named "${VMNAME}" then
+			set vm to virtual machine named "${VMNAME}"
+			if status of vm is started then stop vm
+			repeat
+				if status of vm is stopped then exit repeat
+			end repeat
+			delete virtual machine named "${VMNAME}"
+		end if
 	end tell
 	END
 	)


### PR DESCRIPTION
This allows the script to finish the cleanup even when the VM is no longer found (e.g. manually deleted)