### PR TITLE
get_kubeconfig.sh: make output file path configurable

### DIFF
--- a/slemicro/README.md
+++ b/slemicro/README.md
@@ -243,11 +243,11 @@ for file in vm-*; do ./delete_vm.sh -f ${file} &; done; wait
 
 This script is intended to easily get the Kubeconfig file of the K3s/RKE2 cluster created with the `create_vm.sh` script.
 
-> NOTE: The kubeconfig file will be created in a temporary file that will be the script output.
-
 If Rancher is not deployed, it tries to get the Kubeconfig file via ssh, otherwise it leverages the Rancher API.
 
 You can use the same `-f` or `-n` parameters as well, an extra `-i` parameter to specify the IP manually or the `-w` flag that will wait until the kubeconfig is available.
+
+By default the kubeconfig is output on stdout, or you can use `-o` to specify an output filename.
 
 ### Prerequisites
 
@@ -261,19 +261,22 @@ The previous environment variables can be used but it requires a few less.
 
 ```bash
 $ ./get_kubeconfig.sh
-/var/folders/t_/vwz7m7x14ll3f_6pszsly1k00000gp/T/tmp.GhEi9ys5
+<kubeconfig contents>
+
+$ ./get_kubeconfig.sh -o $KUBECONFIG
+# Will write/overwrite the KUBECONFIG file
 ```
 
 ```bash
 $ ./get_kubeconfig.sh -h
-Usage: ./get_kubeconfig.sh [-f <path/to/variables/file>] [-n <vmname>] [-i <vmip>]
+Usage: ./get_kubeconfig.sh [-f <path/to/variables/file>] [-n <vmname>] [-i <vmip>] [-o <filename>]
 ```
 
 You can use the script in combination with the `create_vm.sh` one as:
 
 ```bash
 $ ./create_vm.sh -f vm-foobar
-$ KUBECONFIG=$(./get_kubeconfig.sh -w -f vm-foobar)
+$ ./get_kubeconfig.sh -w -f vm-foobar -o $KUBECONFIG
 ```
 
 ## get_ip.sh


### PR DESCRIPTION
Currently we leak files into /tmp which isn't ideal in many cases, so add the option to specify a predictable filename via the env file