### PR TITLE
Added check for .sh files in the combustion directory

### DIFF
--- a/slemicro/create_vm.sh
+++ b/slemicro/create_vm.sh
@@ -159,6 +159,7 @@ if [ -f ${BASEDIR}/combustion/script ]; then
 	
 	# Copy all combustion related files to the final iso destination parsing the vars
 	for file in ${BASEDIR}/combustion/*.sh; do
+		[ -f "$file" ] || break
 		FILENAME=$(basename ${file})
 		envsubst < ${file} > ${TMPDIR}/combustion/${FILENAME}
 		chmod a+x ${TMPDIR}/combustion/${FILENAME}

--- a/slemicro/create_vm.sh
+++ b/slemicro/create_vm.sh
@@ -158,13 +158,14 @@ if [ -f ${BASEDIR}/combustion/script ]; then
 	envsubst < ${BASEDIR}/combustion/script > ${TMPDIR}/combustion/script
 	
 	# Copy all combustion related files to the final iso destination parsing the vars
-	for file in ${BASEDIR}/combustion/*.sh; do
-		[ -f "$file" ] || break
-		FILENAME=$(basename ${file})
-		envsubst < ${file} > ${TMPDIR}/combustion/${FILENAME}
-		chmod a+x ${TMPDIR}/combustion/${FILENAME}
-		echo "./${FILENAME}" >> ${TMPDIR}/combustion/script
-	done
+	if ls ${BASEDIR}/combustion/*.sh >/dev/null 2>&1; then
+		for file in ${BASEDIR}/combustion/*.sh; do
+			FILENAME=$(basename ${file})
+			envsubst < ${file} > ${TMPDIR}/combustion/${FILENAME}
+			chmod a+x ${TMPDIR}/combustion/${FILENAME}
+			echo "./${FILENAME}" >> ${TMPDIR}/combustion/script
+		done
+	fi
 fi
 
 # Create an iso


### PR DESCRIPTION
If there are no files matching *.sh in the combustion directory, the script will fail with the following:

./create_vm.sh: line 161: ./combustion/*.sh: No such file or directory

This check will make sure the loop doesn't try to run against a file named "*.sh".