### PR TITLE
Fix optstring argument in optargs in get_ip.sh script

### DIFF
--- a/slemicro/get_ip.sh
+++ b/slemicro/get_ip.sh
@@ -17,7 +17,7 @@ usage(){
 	EOF
 }
 
-while getopts 'f:nh' OPTION; do
+while getopts 'f:n:h' OPTION; do
 	case "${OPTION}" in
 		f)
 			[ -f "${OPTARG}" ] && ENVFILE="${OPTARG}" || die "Parameters file ${OPTARG} not found" 2


### PR DESCRIPTION
This fixes a bug when a VM name is passed via -n option.