### PR TITLE
Allow for configurable registration url

### DIFF
--- a/slemicro/combustion/01_registration.sh
+++ b/slemicro/combustion/01_registration.sh
@@ -6,5 +6,7 @@ if [ "${REGISTER}" = true ]; then
 	if ! which SUSEConnect > /dev/null 2>&1; then
 		zypper --non-interactive install suseconnect-ng
 	fi
-	SUSEConnect --email "${EMAIL}" --url https://scc.suse.com --regcode "${REGCODE}"
+
+	SCC_REGISTRATION_HOST=${SCC_REGISTRATION_HOST:-https://scc.suse.com}
+	SUSEConnect --email "${EMAIL}" --url "${SCC_REGISTRATION_URL}" --regcode "${REGCODE}"
 fi


### PR DESCRIPTION
This enables the combustion script to perform the SCC registration against an RMT/SUMA